### PR TITLE
ci: fix payload migrate hang (--forceAcceptWarning)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -36,6 +36,12 @@ Because `wrangler.jsonc` declares a Hyperdrive binding without a
 `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE` to the same direct
 Postgres URL used for migrations — wrangler uses it to emulate the binding.
 
+## Migration `--forceAcceptWarning`
+
+The migrate step passes `--forceAcceptWarning` because the prod DB contains a
+`dev|-1` marker row (from a past `payload dev` push-mode run). Without the flag,
+`payload migrate` prompts interactively, which hangs in CI with no TTY.
+
 ## Runtime Secrets
 
 Secrets used at runtime by the Workers (Spotify credentials, Clerk secret key,

--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Typecheck
         run: pnpm --dir apps/cms exec tsc --noEmit
 
+      # --forceAcceptWarning: the prod DB has a dev-mode marker row in
+      # payload_migrations (from a past `payload dev` push). Without this flag
+      # `payload migrate` prompts interactively, which hangs in CI (no TTY).
       - name: Run database migrations
-        run: pnpm --dir apps/cms run payload migrate
+        run: pnpm --dir apps/cms run payload migrate --forceAcceptWarning
         env:
           NODE_ENV: production
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}


### PR DESCRIPTION
First real deploy-cms run hung: prod payload_migrations has a dev-mode marker row that makes `payload migrate` prompt interactively (no TTY in CI). Flag auto-accepts. Verified against prod: init applied, nothing pending, flag forwards through pnpm correctly.