### PR TITLE
ci: Hyperdrive env for CMS build step

### DIFF
--- a/.github/workflows/deploy-cms.yml
+++ b/.github/workflows/deploy-cms.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
           PAYLOAD_SECRET: ${{ secrets.PAYLOAD_SECRET }}
+          CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: ${{ secrets.DATABASE_URL_PROD }}
 
       - name: Deploy
         run: pnpm --dir apps/cms exec wrangler deploy


### PR DESCRIPTION
next build's page-data collection loads payload.config → getPlatformProxy needs CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE, same as the migrate step. Migrate is already green in CI (dev-mode marker row removed from prod payload_migrations; zero schema drift verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CMS deployment process to provide the required database connection configuration during builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->