### PR TITLE
ci: PAYLOAD_API_KEY at site build time

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -10,6 +10,7 @@ Two workflows deploy the monorepo to Cloudflare Workers.
 |---|---|---|
 | `CLOUDFLARE_API_TOKEN` | Both | CF API token with **Workers Scripts:Edit** permission on the account |
 | `DATABASE_URL_PROD` | CMS | Direct Postgres connection string (not Hyperdrive — migrations run outside Workers) |
+| `PAYLOAD_API_KEY` | Site | Baked at build time into the site bundle for authenticated CMS reads (guestbook, media types) |
 | `PAYLOAD_SECRET` | CMS | Payload CMS encryption secret (same value as the Worker secret) |
 
 ### Repository Variables

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -45,6 +45,7 @@ jobs:
         env:
           PUBLIC_CMS_URL: ${{ vars.PUBLIC_CMS_URL }}
           PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          PAYLOAD_API_KEY: ${{ secrets.PAYLOAD_API_KEY }}
 
       - name: Deploy (production)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
lib/cms.ts bakes the API key via import.meta.env for authenticated CMS reads (guestbook, media-types). Old CF Builds CI had it as build var; GH Actions was missing it → prod guestbook rendered empty. Key recovered (decrypted from DB, verified against CMS) and stored as GH secret.